### PR TITLE
Remove copied tmp Eddie instead of original Eddie.

### DIFF
--- a/repository/linux_appimage/apprun.cli.sh
+++ b/repository/linux_appimage/apprun.cli.sh
@@ -11,7 +11,7 @@ TMPDIR=$(mktemp -d)
 cp $ARGV0 "$TMPDIR/"
 cd $TMPDIR
 $ARGV0 --appimage-extract >/dev/null 2>&1
-rm $ARGV0
+rm $(basename $ARGV0)
 cd "squashfs-root/opt/eddie-cli/"
 echo AppImage, run
 ./eddie-cli --path=home "$@"


### PR DESCRIPTION
- $ARGV0 was the absolute path of the original AppImage.